### PR TITLE
Add allowedDevOrigins to next.config.ts for cross-origin dev access

### DIFF
--- a/dashboard/next.config.ts
+++ b/dashboard/next.config.ts
@@ -1,7 +1,11 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  allowedDevOrigins: [
+    'http://localhost:53350',
+    'http://127.0.0.1:53350',
+    'http://10.10.10.168:53350', // Add your server's IP and port here
+  ],
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

This PR adds the `allowedDevOrigins` option to `dashboard/next.config.ts` to explicitly allow cross-origin requests to the Next.js dev server from:
- localhost:53350
- 127.0.0.1:53350
- 10.10.10.168:53350

This resolves the Next.js warning about cross-origin requests and future-proofs the development setup for remote access.

No production impact. See https://nextjs.org/docs/app/api-reference/config/next-config-js/allowedDevOrigins for details.

---
If a PR template exists, please update this description to match the template.